### PR TITLE
Fix for debian jessie (with bison 3.0.x)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,8 +52,8 @@ noinst_HEADERS = tengcache.h tengcode.h tengcontenttype.h \
                  tengfunction.h tenginstruction.h tenglex1.h \
                  tengparsercontext.h tengparservalue.h tengprocessor.h \
                  tengprogram.h tengsourcelist.h tengtemplate.h \
-                 tengutil.h tengwriter.h tengsyntax.h tengconfiguration.h \
-		 tengplatform.h tengaux.h
+                 tengutil.h tengwriter.h tengsyntax.hh tengconfiguration.h \
+                 tengplatform.h tengaux.h
 
 # compile this library
 lib_LTLIBRARIES = libteng.la
@@ -73,8 +73,8 @@ libteng_la_LDFLAGS = @VERSION_INFO@
 libteng_la_LIBADD = $(LTLIBOBJS) ${DEPENS_LIBS}
 
 # explicit rules for proper flex & bison sources compilation
-tenglex2.cc: tenglex2.ll tengsyntax.h tengsyntax.cc
-tengsyntax.h: tengsyntax.yy
+tenglex2.cc: tenglex2.ll tengsyntax.hh tengsyntax.cc
+tengsyntax.hh: tengsyntax.yy
 tengsyntax.cc: tengsyntax.yy
 
 # test program
@@ -82,3 +82,4 @@ tengsyntax.cc: tengsyntax.yy
 
 doc:
 	doxygen
+

--- a/src/tenglex2.h
+++ b/src/tenglex2.h
@@ -37,7 +37,7 @@
 #ifndef TENGLEX2_H
 #define TENGLEX2_H
 
-#include "tengsyntax.h"
+#include "tengsyntax.hh"
 
 /** @short Maximal depth of lex stack.
  */

--- a/src/tenglex2.ll
+++ b/src/tenglex2.ll
@@ -61,7 +61,7 @@
 #include <stdio.h>
 
 #include "tengyystype.h"
-#include "tengsyntax.h"
+#include "tengsyntax.hh"
 #include "tengparsercontext.h"
 #include "tengerror.h"
 

--- a/src/tengsyntax.yy
+++ b/src/tengsyntax.yy
@@ -37,10 +37,10 @@
  *             Better error reporting when unexpected EOF
  */
 
+%param {void *context}
+
 // all external symbols will be prefixed with tengSyntax_
 %name-prefix="tengSyntax_"
-
-%lex-param {void * scanner}
 
 // we want to have y.tab.h
 %defines
@@ -85,7 +85,7 @@ namespace Teng {
 
 // local function prototypes
 static int yylex(YYSTYPE *leftValue, void *context);
-static int yyerror(const char *msg);
+static int yyerror(void *context, const char *msg);
 
 // errlog function
 static void printUnexpectedElement(ParserContext_t *context,
@@ -2272,7 +2272,7 @@ static int yylex(YYSTYPE *leftValue, void *context)
   * Function is unusable, because it does not know parser context :-((
   * @return 0=ok.
   * @param msg Error message to show. */
-static int yyerror(const char *msg)
+static int yyerror(void *context, const char *msg)
 {
 #if YYDEBUG
     // if debug enabled


### PR DESCRIPTION
Debian Jessie uses bison version 3.0.2 which generate different parser than bison 2.0.5 used in Debian wheezy. Here are modification which are not backward compatible!