### PR TITLE
Save fuzzer exit code and re-use it later

### DIFF
--- a/fuzzer-coverage.sh
+++ b/fuzzer-coverage.sh
@@ -31,6 +31,8 @@ OUT="${ROOT}/fuzzer-coverage-html"
 
 rm -f "${PROF_RAW}" "${PROF_DATA}"
 LLVM_PROFILE_FILE="${PROF_RAW}" "${BIN}" "$@"
+FUZZER_EXIT_CODE="$?"
 llvm-profdata merge -sparse "${PROF_RAW}" -o "${PROF_DATA}"
 llvm-cov show "${BIN}" -output-dir="${OUT}" -instr-profile="${PROF_DATA}" -format=html -Xdemangler c++filt -Xdemangler -n -ignore-filename-regex=".*glib-2.0.*"
+exit "${FUZZER_EXIT_CODE}"
 


### PR DESCRIPTION
Use saved exit code to indicate success or failure (useful for CI jobs).