### PR TITLE
libteng5 replace fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,9 +35,9 @@
 #
 
 # initialize autoconf
-AC_INIT([teng], [5.0.1], [teng@firma.seznam.cz])
+AC_INIT([teng], [5.0.2], [teng@firma.seznam.cz])
 # https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-VERSION_INFO="-version-info 5:0:0"
+VERSION_INFO="-version-info 5:2:0"
 
 # enable silent builds (disable with --disable-silent-rules)
 # or simply do "make V=1"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libteng (5.0.2) UNRELEASED; urgency=medium
+
+  * fix: regression in func replace
+
+ -- Frantisek Boranek <frantisek.boranek@firma.seznam.cz>  Tue, 24 Mar 2020 15:01:41 +0000
+
 libteng (5.0.1) stable; urgency=medium
 
   * #! v5.0.0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-libteng (5.0.2) UNRELEASED; urgency=medium
+libteng (5.0.2) stable; urgency=medium
 
   * fix: regression in func replace
 
- -- Frantisek Boranek <frantisek.boranek@firma.seznam.cz>  Tue, 24 Mar 2020 15:01:41 +0000
+ -- Frantisek Boranek <frantisek.boranek@firma.seznam.cz>  Tue, 24 Mar 2020 15:25:21 +0000
 
 libteng (5.0.1) stable; urgency=medium
 

--- a/src/functionstring.h
+++ b/src/functionstring.h
@@ -529,7 +529,7 @@ Result_t replace(Ctx_t &ctx, const Args_t &args) {
     tmp.reserve(2 * text->size());
 
     // empty pattern breaks algorithm bellow
-    if (!pattern->empty()) {
+    if (!pattern->empty() && text->size() >= pattern->size()) {
         auto i = 0lu;
         for (auto upto = text->size() - pattern->size() + 1; i < upto;) {
             if (text->compare(i, pattern->size(), *pattern) == 0) {
@@ -540,6 +540,8 @@ Result_t replace(Ctx_t &ctx, const Args_t &args) {
 
         // append text suffix (the tail that can't contain pattern)
         while (i < text->size()) tmp.push_back((*text)[i++]);
+    } else {
+        tmp = *text;
     }
 
     // done

--- a/src/tests/fun-string.cc
+++ b/src/tests/fun-string.cc
@@ -530,6 +530,54 @@ SCENARIO(
             }
         }
 
+        WHEN("The string is empty") {
+            Teng::Error_t err;
+            auto t = "${replace('', 'nono', 'repl')}";
+            auto result = g(err, t, root);
+
+            THEN("The result origin string") {
+                std::vector<Teng::Error_t::Entry_t> errs;
+                ERRLOG_TEST(err.getEntries(), errs);
+                REQUIRE(result == "");
+            }
+        }
+
+        WHEN("The string is shorter then pattern") {
+            Teng::Error_t err;
+            auto t = "${replace('1', 'nono', 'repl')}";
+            auto result = g(err, t, root);
+
+            THEN("The result origin string") {
+                std::vector<Teng::Error_t::Entry_t> errs;
+                ERRLOG_TEST(err.getEntries(), errs);
+                REQUIRE(result == "1");
+            }
+        }
+
+        WHEN("The string is the same langht as pattern") {
+            Teng::Error_t err;
+            auto t = "${replace('1234', 'nono', 'repl')}";
+            auto result = g(err, t, root);
+
+            THEN("The result origin string") {
+                std::vector<Teng::Error_t::Entry_t> errs;
+                ERRLOG_TEST(err.getEntries(), errs);
+                REQUIRE(result == "1234");
+            }
+        }
+
+        WHEN("The string is the same as pattern") {
+            Teng::Error_t err;
+            auto t = "${replace('nono', 'nono', 'repl')}";
+            auto result = g(err, t, root);
+
+            THEN("The result origin string") {
+                std::vector<Teng::Error_t::Entry_t> errs;
+                ERRLOG_TEST(err.getEntries(), errs);
+                REQUIRE(result == "repl");
+            }
+        }
+
         WHEN("The pattern found two times") {
             Teng::Error_t err;
             auto t = "${replace('some text some text', 'some', 'repl')}";


### PR DESCRIPTION
- bumb revision to have: /usr/lib/x86_64-linux-gnu/libteng.so.5 -> libteng.so.5.0.2
- fix func `replace` in prevous version was legal to call even with empty string as a source text