### PR TITLE
docs: fix typos and grammar errors in comments and error messages

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -55,7 +55,7 @@ namespace Teng {
 /**
  * @short Creates key for given file.
  *
- * The key (normalizad filenanme) is added into given key vector.
+ * The key (normalized filename) is added into given key vector.
  *
  * @param filename filename
  * @return key key vector

--- a/src/error.cc
+++ b/src/error.cc
@@ -102,7 +102,7 @@ std::vector<Error_t::Entry_t> make_error_log(const Records_t &records) {
         };
     };
 
-    // appends entry to log with according to source code positions
+    // appends entry to log according to source code positions
     auto push_back = [] (auto &&result, Error_t::Entry_t &&entry) {
         result.push_back(std::move(entry));
         for (auto i = result.size() - 1; i > 0; --i) {

--- a/src/lex2.cc
+++ b/src/lex2.cc
@@ -186,7 +186,7 @@ Lex2_t::Lex2_t(const Configuration_t *params, bool utf8, Error_t &err)
     current_start_condition(INITIAL)
 {
     if (teng_lex_init(&yyscanner))
-        throw std::runtime_error("can't initalize lex2: " + strerr(errno));
+        throw std::runtime_error("can't initialize lex2: " + strerr(errno));
 }
 
 Lex2_t::~Lex2_t() {

--- a/src/semanticif.cc
+++ b/src/semanticif.cc
@@ -53,7 +53,7 @@ namespace {
  * program.
  */
 void finalize_if_branch(Context_t *ctx, int32_t shift) {
-    // TODO(burlog): optimalize if
+    // TODO(burlog): optimize if
 
     // calculate real jump address for last elif/else branch
     auto branch_addr = ctx->curr_branch_addrs().pop();
@@ -98,8 +98,8 @@ void generate_if(Context_t *ctx, const Token_t &token, bool valid_expr) {
 
     // warn about invalid expression
     if (!valid_expr) {
-        auto msg_end_if = "You forgot write condition of the if statement";
-        auto msg_end_el = "You forgot write condition of the elif statement";
+        auto msg_end_if = "You forgot to write the condition of the if statement";
+        auto msg_end_el = "You forgot to write the condition of the elif statement";
         auto msg_def_if = "Invalid expression in the if statement condition";
         auto msg_def_el = "Invalid expression in the elif statement condition";
         switch (ctx->unexpected_token) {
@@ -123,7 +123,7 @@ void generate_endif(Context_t *ctx, const Pos_t *inv_pos) {
     // update if/else condition jump
     finalize_if_branch(ctx, 1);
 
-    // now is known the endif address so we can update if brachnes end jumps
+    // now is known the endif address so we can update if branches end jumps
     while (!ctx->curr_branch_addrs().empty()) {
         auto branch_addr = ctx->curr_branch_addrs().pop();
         auto &instr = (*ctx->program)[branch_addr].as<Jmp_t>();
@@ -133,7 +133,7 @@ void generate_endif(Context_t *ctx, const Pos_t *inv_pos) {
     // break possible invalid print optimization
     generate<Noop_t>(ctx);
 
-    // warn if there is invalid tokens
+    // warn if there are invalid tokens
     if (inv_pos) {
         logWarning(
             ctx,
@@ -152,7 +152,7 @@ void generate_else(Context_t *ctx, const Token_t &token, bool invalid) {
     ctx->curr_branch_addrs().push(ctx->program->size());
     generate<Jmp_t>(ctx, token.pos);
 
-    // warn if there is invalid tokens
+    // warn if there are invalid tokens
     if (invalid) {
         logWarning(
             ctx,


### PR DESCRIPTION
## Summary

Fix 9 documentation issues across 4 files:

- `src/cache.h`: "normalizad filenanme" → "normalized filename"
- `src/lex2.cc`: "initalize" → "initialize" in error message string
- `src/error.cc`: remove extraneous word "with" in comment
- `src/semanticif.cc`: "optimalize" → "optimize", "brachnes" → "branches"
- `src/semanticif.cc`: "You forgot write condition" → "You forgot to write the condition" (×2 error messages)
- `src/semanticif.cc`: "there is invalid tokens" → "there are invalid tokens" (×2 comments)

No functional changes — comments and error message strings only.